### PR TITLE
refactor: add list of episodes

### DIFF
--- a/cmd/toru/stream.go
+++ b/cmd/toru/stream.go
@@ -59,16 +59,20 @@ func StreamTorrent(torfile string, cl *libtorrent.Client) (string, error) {
 	}
 	success.Success("Success!")
 
-	torrentFiles := len(t.Files())
+	torrentFiles := t.Files()
 	var episode int
 
-	if torrentFiles != 1 {
-		ep, _ := Prompt("Choose an episode")
+	if len(torrentFiles) > 1 {
+		for x := range torrentFiles {
+			fmt.Println(x, torrentFiles[x].DisplayPath())
+		}
+
+		ep, _ := Prompt("Choose an episode from list")
 		episode, err = strconv.Atoi(ep)
 		if err != nil {
 			return "", errors.New("episode must be numeric")
 		}
-		if episode > torrentFiles {
+		if episode >= len(torrentFiles) {
 			return "", errors.New("episode doesn't exist")
 		}
 	}

--- a/pkg/libtorrent/client.go
+++ b/pkg/libtorrent/client.go
@@ -131,11 +131,7 @@ func (c *Client) handler(w http.ResponseWriter, r *http.Request) {
 		ih := ff.InfoHash().String()
 
 		if ih == hash {
-			if ep == 0 {
-				ep = 1
-			}
-
-			f, err := GetVideoFile(ff, ep-1)
+			f, err := GetVideoFile(ff, ep)
 			if err != nil {
 				log.Println(err)
 				return


### PR DESCRIPTION
I've faced a problem while selecting the series, it was that each time `t.Files()` returns files in a different order. Because of this, the series selection was incorrect (for example 1th episode can be at the end of list). 
Therefore, I decided to fix this bug a little and added a list of episodes, and based on this, the user will choose the exact episode.