### PR TITLE
[Feat]: Add more verbose episode prompt with defaulting to latest episode

### DIFF
--- a/cmd/toru/stream.go
+++ b/cmd/toru/stream.go
@@ -1,10 +1,8 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -63,13 +61,9 @@ func StreamTorrent(torfile string, cl *libtorrent.Client) (string, error) {
 	var episode int
 
 	if torrentFiles != 1 {
-		ep, _ := Prompt("Choose an episode")
-		episode, err = strconv.Atoi(ep)
+		episode, err = PromptEpisodeInRangeWithDefaultToMax(1, torrentFiles)
 		if err != nil {
-			return "", errors.New("episode must be numeric")
-		}
-		if episode > torrentFiles {
-			return "", errors.New("episode doesn't exist")
+			return "", err
 		}
 	}
 

--- a/cmd/toru/ui.go
+++ b/cmd/toru/ui.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
+	"strconv"
 
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
@@ -43,6 +45,27 @@ func Prompt(prompt string) (string, error) {
 
 	fmt.Println(style.Render(val))
 	return val, nil
+}
+
+func PromptEpisodeInRangeWithDefaultToMax(min int, max int) (int, error) {
+	val, err := Prompt(fmt.Sprintf("Choose an episode %d-%d", min, max))
+	if err != nil {
+		return -1, err
+	}
+
+	if val == "" {
+		return max, nil
+	}
+
+	episode, err := strconv.Atoi(val)
+	if err != nil {
+		return -1, errors.New("episode must be numeric")
+	}
+	if episode > max || episode < min {
+		return -1, errors.New("episode doesn't exist")
+	}
+
+	return episode, nil
 }
 
 func prettyPrint(str string) {


### PR DESCRIPTION
### Problem
This would solve problem with watching ongoings when all you need is to
only to quickly select latest episode. I struggled remembering it's number especially when not present in the prompt.
### Solution
Prompt now will return latest episode when left empty also showing range in the prompt message.