### PR TITLE
[Fix]: explicitly sort files before selecting by index

### DIFF
--- a/cmd/toru/stream.go
+++ b/cmd/toru/stream.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"path"
 	"strings"
 	"time"
 
@@ -78,9 +77,9 @@ func StreamTorrent(torfile string, cl *libtorrent.Client) (player.MediaEntry, er
 		}
 	}()
 
-	filename := path.Base(files[episode-1].Path())
+	p, _ := libtorrent.GetVideoFile(t, episode)
 
-	return player.MediaEntry{Title: filename, URL: link}, nil
+	return player.MediaEntry{Title: p.DisplayPath(), URL: link}, nil
 }
 
 // play a single torrent from a provided magnet, torrent or torrent URL

--- a/pkg/libtorrent/client.go
+++ b/pkg/libtorrent/client.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -93,8 +94,20 @@ func (c *Client) ServeTorrents(ctx context.Context, torrents []*torrent.Torrent)
 	}
 }
 
+func getSortedFilesList(t *torrent.Torrent) []*torrent.File {
+	// Almost zero copy cause pointers used
+	files := make([]*torrent.File, len(t.Files()))
+	copy(files, t.Files())
+
+	slices.SortFunc(files, func(a, b *torrent.File) int {
+		return strings.Compare(a.Path(), b.Path())
+	})
+
+	return files
+}
+
 func GetVideoFile(t *torrent.Torrent, episode int) (*torrent.File, error) {
-	f := t.Files()[episode]
+	f := getSortedFilesList(t)[episode-1]
 	ext := path.Ext(f.Path())
 	switch ext {
 	case ".mp4", ".mkv", ".avi", ".avif", ".av1", ".mov", ".flv", ".f4v", ".webm", ".wmv", ".mpeg", ".mpg", ".mlv", ".hevc", ".flac", ".flic":
@@ -129,13 +142,9 @@ func (c *Client) handler(w http.ResponseWriter, r *http.Request) {
 	for _, ff := range ts {
 		<-ff.GotInfo()
 		ih := ff.InfoHash().String()
-
+		
 		if ih == hash {
-			if ep == 0 {
-				ep = 1
-			}
-
-			f, err := GetVideoFile(ff, ep-1)
+			f, err := GetVideoFile(ff, ep)
 			if err != nil {
 				log.Println(err)
 				return

--- a/pkg/libtorrent/client.go
+++ b/pkg/libtorrent/client.go
@@ -142,7 +142,7 @@ func (c *Client) handler(w http.ResponseWriter, r *http.Request) {
 	for _, ff := range ts {
 		<-ff.GotInfo()
 		ih := ff.InfoHash().String()
-		
+
 		if ih == hash {
 			f, err := GetVideoFile(ff, ep)
 			if err != nil {


### PR DESCRIPTION
Sometimes without sorting it might not work for example selecting 6 episode of Yozakura-san family from Anilibria would result in ep 1 being loaded without sorting.