### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ toru search --latest --json | jq -r '.[]|.Name,.Magnet'
 
 ```sh
 toru search --json "one piece" > cache.json
-toru search --from-json cacne.json --interactive
+toru search --from-json cache.json --interactive
 ```
 
 #### Output in a human readable format:


### PR DESCRIPTION
Fixes small typo in "Open a cached search session from a json file" section